### PR TITLE
Use the most advanced `gpt-4o` to replce deprecating `gpt-4-vision-preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ source pdf2md/bin/activate
 (pdf2md) $ ./pdf2md.py --help
 usage: pdf2md.py [-h] [-c] [--first-page FIRST_PAGE] [--last-page LAST_PAGE] [--dpi DPI] pdf [output]
 
-Script for converting PDF to Markdown via OpenAI's `gpt-4-vision` model.
+Script for converting PDF to Markdown via OpenAI's `gpt-4o` model.
 
 positional arguments:
   pdf                   path to input PDF file to convert to Markdown

--- a/pdf2md.py
+++ b/pdf2md.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Script for converting PDF to Markdown via OpenAI's `gpt-4-vision` model."""
+"""Script for converting PDF to Markdown via OpenAI's `gpt-4o` model."""
 
 import backoff
 import base64
@@ -30,7 +30,7 @@ def completions_with_backoff(**kwargs):
     return openai.chat.completions.create(**kwargs)
 
 def page_image2md(page_image):
-    """Prompt OpenAI `gpt-4-vision-preview` model to generate Markdown text from given PIL.Image"""
+    """Prompt OpenAI `gpt-4o` model to generate Markdown text from given PIL.Image"""
     # encode image with base64 url encoding in order to pass it to the OpenAI API
     with BytesIO() as buffer:
         page_image.save(buffer, format=page_image.format)
@@ -40,7 +40,7 @@ def page_image2md(page_image):
         )
     # get completions from OpenAI API
     response = completions_with_backoff(
-        model="gpt-4-vision-preview",
+        model="gpt-4o",
         seed=0,
         temperature=0.0,
         messages=[


### PR DESCRIPTION
Hi @zyocum,

Thanks for your great work on this amazing PDF to Markdown tool. I just tested it, and it's really awesome!

Because the GPT-4-Vision model is being deprecated, I've confirmed that `gpt-4o` can be directly used to replace it, it'll be great if this patch can be merged as the default model, it's more powerful with more competitive pricing and performance.

Pricing comparison:
- gpt-4o                $5.00 / 1M input tokens, $15 / 1M output tokens
- gpt-4-vision-preview $10.00 / 1M input tokens, $30 / 1M output tokens

Deprecation info reference:

> On June 6th, 2024, we notified developers using gpt-4-32k and gpt-4-vision-preview of their upcoming deprecations in one year and six months respectively. As of June 17, 2024, only existing users of these models will be able to continue using them.

- https://platform.openai.com/docs/deprecations/2024-06-06-gpt-4-32k-and-vision-preview-models